### PR TITLE
[FIX]: Allow variables containing lists in 'in' operator queries

### DIFF
--- a/test/pplus_firestore/api_test.exs
+++ b/test/pplus_firestore/api_test.exs
@@ -711,17 +711,12 @@ defmodule PPlusFireStore.APITest do
       # an AST and then call the Code.eval_quoted/3 function to execute it.
 
       assert_raise ArgumentError, "IN operator requires a list as the right side of the expression\n\n", fn ->
-        ast =
-          quote do
-            query =
-              "books"
-              |> from()
-              |> where("author" in "John Doe")
+        query =
+          "books"
+          |> from()
+          |> where("author" in "John Doe")
 
-            API.run_query(token, parent, query)
-          end
-
-        Code.eval_quoted(ast, [token: token, parent: @parent], __ENV__)
+        API.run_query(token, @parent, query)
       end
     end
 
@@ -745,17 +740,12 @@ defmodule PPlusFireStore.APITest do
       # an AST and then call the Code.eval_quoted/3 function to execute it.
 
       assert_raise ArgumentError, "IN operator requires a list as the right side of the expression\n\n", fn ->
-        ast =
-          quote do
-            query =
-              "books"
-              |> from()
-              |> where("author" not in "John Doe")
+        query =
+          "books"
+          |> from()
+          |> where("author" not in "John Doe")
 
-            API.run_query(token, parent, query)
-          end
-
-        Code.eval_quoted(ast, [token: token, parent: @parent], __ENV__)
+        API.run_query(token, @parent, query)
       end
     end
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix handling of 'in' operator with non-list variables

- Add runtime error check for 'in' and 'not in' operators

- Simplify test cases for 'in' and 'not in' operator errors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query.ex</strong><dd><code>Improve error handling for 'in' operator in queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/pplus_firestore/query.ex

<li>Removed compile-time checks for 'in' operator<br> <li> Added runtime error handling for 'in' and 'not in'<br> <li> Simplified logic for parsing expressions


</details>


  </td>
  <td><a href="https://github.com/PagoPlus/pplus-firestore/pull/24/files#diff-177470f11f2342490772074f102c77fe2f4974ebe756001e5c7815d0fceb7653">+11/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_test.exs</strong><dd><code>Simplify tests for 'in' operator error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/pplus_firestore/api_test.exs

<li>Simplified test cases for 'in' operator errors<br> <li> Removed AST conversion in tests<br> <li> Directly evaluated queries in tests


</details>


  </td>
  <td><a href="https://github.com/PagoPlus/pplus-firestore/pull/24/files#diff-ba89acd3b3b561ce3c9e17df4f87670646110103aaef7058758621eeda10e966">+10/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>